### PR TITLE
Fix Radio buttons value when submitting a form with errors

### DIFF
--- a/src/Field/AbstractType.php
+++ b/src/Field/AbstractType.php
@@ -47,9 +47,13 @@ abstract class AbstractType
     {
         $this->options = array_merge($this->options, $attributes);
 
-        $value = request($this->name, $this->getOption('value'));
-
-        $this->setValue( old($this->name, $value) );
+        if (func_num_args() == 3) {
+            $value = func_get_arg(2);
+            $this->setValue($value);
+        } else {
+            $value = request($this->name, $this->getOption('value'));
+            $this->setValue( old($this->name, $value) );
+        }
 
         if($this->isSkipped()) {
             return;

--- a/src/Field/Radio.php
+++ b/src/Field/Radio.php
@@ -14,6 +14,14 @@ class Radio extends Text
             $this->options['checked'] = 'checked';
         }
 
-        return parent::render($attributes, $viewData);
+        $this->setValue($value);
+
+        if($this->isSkipped()) {
+            return;
+        }
+
+        return view($this->getView(), array_merge([
+            'field' => $this
+        ], $viewData));
     }
 }

--- a/src/Field/Radio.php
+++ b/src/Field/Radio.php
@@ -14,14 +14,6 @@ class Radio extends Text
             $this->options['checked'] = 'checked';
         }
 
-        $this->setValue($value);
-
-        if($this->isSkipped()) {
-            return;
-        }
-
-        return view($this->getView(), array_merge([
-            'field' => $this
-        ], $viewData));
+        return parent::render($attributes, $viewData, $value);
     }
 }


### PR DESCRIPTION
Radio buttons, when in a group, had their values replaced on form submit with errors which ruined the whole request data.